### PR TITLE
Automatically scroll down after creating a new suggester

### DIFF
--- a/src/customSuggesterSettings.ts
+++ b/src/customSuggesterSettings.ts
@@ -222,6 +222,10 @@ export class CustomSuggesterSettingTab extends PluginSettingTab {
 								this.applySettingsUpdate();
 
 								this.debounceDisplay();
+								// Scroll to the bottom of the settings container to view the newly added suggester
+								setTimeout(() => {
+									this.containerEl.scrollTop = this.containerEl.scrollHeight;
+								}, 10);
 							});
 						});
 					}


### PR DESCRIPTION
Related to #2

Implements automatic scrolling to the bottom of the settings container when a new suggester is added in the Custom Suggester plugin settings.

- Adds a `setTimeout` function to scroll to the bottom of the settings container after a new suggester is created. This ensures that users can immediately see and modify the newly added suggester without manually scrolling down.
- The scrolling action is triggered after the display function is called, ensuring that the new suggester is rendered before attempting to scroll.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Quorafind/Obsidian-Custom-Suggester/issues/2?shareId=13eb1005-722c-4dba-acda-564548e527f3).